### PR TITLE
🐛 redirect github link to public page

### DIFF
--- a/data/navigation.toml
+++ b/data/navigation.toml
@@ -2,7 +2,7 @@
 contact = "/contact"
 about = "/about"
 legals = "/legals"
-github = "https://github.com/link-society/kubevisor"
+github = "https://github.com/link-society"
 
 [[menu]]
 


### PR DESCRIPTION
This PR provides the following changes:
- [x] :bug: GitHub link 

The previous link was pointing to a private repository.