### PR TITLE
🐛 Fix path to API documentation

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -79,7 +79,7 @@ jobs:
         uses: actions/download-artifact@master
         with:
           name: graphql-apidoc
-          path: static/apidoc
+          path: static/api-doc
 
       - name: setup@hugo
         uses: peaceiris/actions-hugo@v2


### PR DESCRIPTION
This PR provides the following changes:

 - [x] :bug: Set path to `static/api-doc` instead of `static/apidoc`